### PR TITLE
Catch Disconnect() in wait after calling recv

### DIFF
--- a/lib/hpfeeds.py
+++ b/lib/hpfeeds.py
@@ -200,7 +200,14 @@ class HPC(object):
 	def wait(self, timeout=1):
 		self.s.settimeout(timeout)
 
-		d = self.recv()
+		try:
+			d = self.recv()
+		except Disconnect:
+			logger.info('Disconnected from broker (in wait).')
+			if self.reconnect:
+				self.tryconnect()
+			return None
+
 		if not d: return None
 
 		self.unpacker.feed(d)


### PR DESCRIPTION
to avoid:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 390, in run
    result = self._run(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.7/dist-packages/Conpot-0.2.2-py2.7.egg/conpot/logging/log_worker.py", line 41, in start
    self.friends_feeder.log(json.dumps(event, default=self.json_default))
  File "/usr/local/lib/python2.7/dist-packages/Conpot-0.2.2-py2.7.egg/conpot/logging/hpfriends.py", line 36, in log
    error_msg = self.hpc.wait()
  File "/usr/local/lib/python2.7/dist-packages/hpfeeds.py", line 203, in wait
    d = self.recv()
  File "/usr/local/lib/python2.7/dist-packages/hpfeeds.py", line 88, in recv
    if not d: raise Disconnect()
Disconnect
<Greenlet at 0xb71b75ccL: <bound method LogWorker.start of <conpot.logging.log_worker.LogWorker object at 0xb71bf82c>>> failed with Disconnect